### PR TITLE
linux-data-type-patch

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -53,6 +53,10 @@ def convert_dcm_jpg(in_dir, out_dir):
 
 def writeSlices(series_tag_values, new_img, i, out_dir):
     image_slice = new_img[:,:,i]
+
+    # Lossless pixel data type conversion from float to 16-bit signed integer
+    image_slice = sitk.Cast(image_slice, sitk.sitkInt16)
+
     writer = sitk.ImageFileWriter()
     writer.KeepOriginalImageUIDOn()
 

--- a/main.py
+++ b/main.py
@@ -333,7 +333,7 @@ if __name__ == '__main__':
     root = Tk()
     root.geometry('700x500')
     root.title('Pycad Convert')
-    root.iconbitmap('utils/logo.ico')
+    # root.iconbitmap('utils/logo.ico')
 
     root.rowconfigure(0, weight=1)
     root.columnconfigure(0, weight=1)


### PR DESCRIPTION
**Relevant Software Specs**

OS: Ubuntu 22.10
Python: 3.10.7
SimpleITK: 2.2.1

**Purpose**

Debugging.

**Issues & Modifications**

M1. Main issue is caused by some kind of data type incompatibility. This is the output when the conversion process starts, right after the paths are being set

```
RuntimeError: Exception thrown in SimpleITK ImageFileWriter_Execute: /tmp/SimpleITK-build/ITK/Modules/IO/GDCM/src/itkGDCMImageIO.cxx:1218:
ITK ERROR: GDCMImageIO(0x558a54954010): A Floating point buffer was passed but the stored pixel type was not specified.This is currently not supported
```

This is solved by adding
`image_slice = sitk.Cast(image_slice, sitk.sitkInt16)`
in the function `writeSlices` of the file `functions.py` directly below the line containing
```
image_slice = new_img[:,:,i]
```

It is worth noting that the above update of the variable `image_slice` does not round or remove information of the slice's pixel values.

M2. A minor issue is

```
"File "/usr/lib/python3.10/tkinter/__init__.py", line 2109, in wm_iconbitmap
    return self.tk.call('wm', 'iconbitmap', self._w, bitmap)
_tkinter.TclError: bitmap "utils/logo.ico" not defined"
```

which is caused when I run `main.py`. In my case this was solved by simply commenting out
```
root.iconbitmap('utils/logo.ico')
```
on `main.py`.

**Testing**

To verify that the resulting software is working properly and without a significant amount of information loss, the following method was applied.

S1. Loaded and displayed one ".nii" file in 3D Slicer.
S2. Converted one ".nii" file to a collection of ".dcm" files based on the updated repo.
S3. Converted the collection of ".dcm" files (from S2) to a ".nii" file, based on the updated repo.
S4. Loaded and displayed one ".nii" file (from S3) in 3D Slicer.

**Conclusion**

The displayed result from S4 did not seem to visibly differ compared to the displayed results from S1 in 3D Slicer, which is a good indicator. However the inverted ".nii" file (from S4) suffered an information loss of >15% compared to the initial ".nii" file (from S1) due to the fact that the latter has a lower size (~15%) compared to the former.